### PR TITLE
메인 화면 내 다이어리UI 제작

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2025-06-09T08:53:01.667927100Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\B\.android\avd\Pixel_7.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,9 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="AndroidElementNotAllowed" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="AndroidMissingOnClickHandler" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="AndroidUnknownAttribute" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ComposePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
@@ -57,5 +60,6 @@
       <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
     </inspection_tool>
+    <inspection_tool class="XmlWrongFileType" enabled="false" level="WARNING" enabled_by_default="false" />
   </profile>
 </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     id("org.jetbrains.kotlin.kapt")
+    id("com.google.gms.google-services")
 }
 
 android {
@@ -45,7 +46,10 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.11.0")
     implementation("com.github.bumptech.glide:glide:4.16.0")
+    implementation(libs.firebase.firestore.ktx)
     kapt("com.github.bumptech.glide:compiler:4.16.0")
+    implementation(platform("com.google.firebase:firebase-bom:33.15.0"))
+    implementation("com.google.firebase:firebase-analytics")
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    id("org.jetbrains.kotlin.kapt")
 }
 
 android {
@@ -43,6 +44,8 @@ dependencies {
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.11.0")
+    implementation("com.github.bumptech.glide:glide:4.16.0")
+    kapt("com.github.bumptech.glide:compiler:4.16.0")
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,7 +40,9 @@ android {
 }
 
 dependencies {
-
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("com.google.android.material:material:1.11.0")
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
@@ -49,6 +51,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.material)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "427795183437",
+    "project_id": "timecapsule-ef83d",
+    "storage_bucket": "timecapsule-ef83d.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:427795183437:android:3c11dafa4b422a6c4b2904",
+        "android_client_info": {
+          "package_name": "com.example.timecapsule"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDUHpuIXIcL2b6ByOcePZO6Cv0wZqHPYB0"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,17 +12,20 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.TimeCapsule"
         tools:targetApi="31">
+
         <activity
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.TimeCapsule">
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".MainDiary" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/timecapsule/CalendarAdpater.kt
+++ b/app/src/main/java/com/example/timecapsule/CalendarAdpater.kt
@@ -1,0 +1,44 @@
+package com.example.timecapsule
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+
+class CalendarAdapter(private val calendarList: List<CalendarCell>) :
+    RecyclerView.Adapter<CalendarAdapter.CalendarViewHolder>() {
+
+    inner class CalendarViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        val dayNumber: TextView = itemView.findViewById(R.id.dayNumber)
+        val dayImage: ImageView = itemView.findViewById(R.id.dayImage)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CalendarViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_calendar_day, parent, false)
+        return CalendarViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: CalendarViewHolder, position: Int) {
+        val item = calendarList[position]
+
+        if (item.day != null) {
+            holder.dayNumber.text = item.day.toString()
+            if (!item.imageUrl.isNullOrEmpty()) {
+                holder.dayImage.visibility = View.VISIBLE
+                Glide.with(holder.itemView.context)
+                    .load(item.imageUrl)
+                    .into(holder.dayImage)
+            } else {
+                holder.dayImage.visibility = View.GONE
+            }
+        } else {
+            holder.dayNumber.text = ""
+            holder.dayImage.visibility = View.GONE
+        }
+    }
+
+    override fun getItemCount(): Int = calendarList.size
+}

--- a/app/src/main/java/com/example/timecapsule/CalendarCell.kt
+++ b/app/src/main/java/com/example/timecapsule/CalendarCell.kt
@@ -1,0 +1,7 @@
+package com.example.timecapsule
+
+data class CalendarCell(
+    val day: Int?, // null이면 빈칸
+    val imageUrl: String? // 해당 날짜에 올린 사진 (없으면 null)
+
+)

--- a/app/src/main/java/com/example/timecapsule/CustomCalendarFragment.kt
+++ b/app/src/main/java/com/example/timecapsule/CustomCalendarFragment.kt
@@ -1,0 +1,59 @@
+package com.example.timecapsule
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import java.util.Calendar
+
+class CustomCalendarFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_custom_calendar, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val recyclerView = view.findViewById<RecyclerView>(R.id.calendarRecyclerView)
+        recyclerView.layoutManager = GridLayoutManager(requireContext(), 7) // 7일 기준
+
+        // 예시 데이터: 일/월/년 기준으로 날짜 칸 만들어서 보여줄 리스트
+        val diaryMap = mapOf(
+            "2025-06-01" to "https://example.com/image1.jpg",
+            "2025-06-04" to "https://example.com/image2.jpg"
+        )
+
+        val calendarList = generateCalendarCells(2025, 6, diaryMap)
+        recyclerView.adapter = CalendarAdapter(calendarList)
+    }
+
+    fun generateCalendarCells(year: Int, month: Int, diaryMap: Map<String, String>): List<CalendarCell> {
+        val calendar = Calendar.getInstance()
+        calendar.set(year, month - 1, 1)
+
+        val firstDayOfWeek = calendar.get(Calendar.DAY_OF_WEEK) // 1 = 일요일
+        val daysInMonth = calendar.getActualMaximum(Calendar.DAY_OF_MONTH)
+
+        val cellList = mutableListOf<CalendarCell>()
+
+        // 앞쪽 빈칸 추가
+        repeat(firstDayOfWeek - 1) {
+            cellList.add(CalendarCell(null, null))
+        }
+
+        for (day in 1..daysInMonth) {
+            val dateKey = String.format("%04d-%02d-%02d", year, month, day)
+            val imageUrl = diaryMap[dateKey] // 있으면 사진 썸네일 URL
+            cellList.add(CalendarCell(day, imageUrl))
+        }
+
+        return cellList
+    }
+}

--- a/app/src/main/java/com/example/timecapsule/DiaryEntry.kt
+++ b/app/src/main/java/com/example/timecapsule/DiaryEntry.kt
@@ -1,0 +1,11 @@
+package com.example.timecapsule
+
+data class DiaryEntry(
+    val imageUrl: String,
+    val emotion: String,
+    val summary: String,
+    val date: String,
+    val latitude: Double,
+    val longitude: Double
+)
+

--- a/app/src/main/java/com/example/timecapsule/MainActivity.kt
+++ b/app/src/main/java/com/example/timecapsule/MainActivity.kt
@@ -1,9 +1,13 @@
 package com.example.timecapsule
 
+import android.content.Intent
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
@@ -13,22 +17,22 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.example.timecapsule.ui.theme.TimeCapsuleTheme
 
-class MainActivity : ComponentActivity() {
+class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
-        setContent {
-            TimeCapsuleTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
-            }
-        }
+
+        // 스플래시 전용 레이아웃 사용 (필요 시 너가 만든 배경화면 등 넣기)
+        setContentView(R.layout.activity_main)
+
+        // 5초(5000ms) 후에 MainDiary로 이동
+        Handler(Looper.getMainLooper()).postDelayed({
+            val intent = Intent(this, MainDiary::class.java)
+            startActivity(intent)
+            finish() // MainActivity는 종료
+        }, 5000)
     }
 }
+
 
 @Composable
 fun Greeting(name: String, modifier: Modifier = Modifier) {

--- a/app/src/main/java/com/example/timecapsule/MainActivity.kt
+++ b/app/src/main/java/com/example/timecapsule/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.example.timecapsule
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
@@ -16,21 +17,47 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.example.timecapsule.ui.theme.TimeCapsuleTheme
+import com.google.firebase.Firebase
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.firestore
+import java.util.UUID
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // 스플래시 전용 레이아웃 사용 (필요 시 너가 만든 배경화면 등 넣기)
+        // 스플래시 전용 레이아웃 사용 (나중에 배경화면 등 넣기)
         setContentView(R.layout.activity_main)
 
-        // 5초(5000ms) 후에 MainDiary로 이동
+        // 🔐 고유 ID 생성 및 저장
+        val userId = getUserId(this)
+
+        // ☁️ Firebase에 user 문서 생성 여부 확인
+        val userRef = Firebase.firestore.collection("user").document(userId)
+        userRef.get().addOnSuccessListener { document ->
+            if (!document.exists()) {
+                userRef.set(mapOf("createdAt" to FieldValue.serverTimestamp()))
+            }
+        }
+
+        // ⏱ 5초 후 메인 다이어리 화면으로 전환
         Handler(Looper.getMainLooper()).postDelayed({
-            val intent = Intent(this, MainDiary::class.java)
-            startActivity(intent)
-            finish() // MainActivity는 종료
+            startActivity(Intent(this, MainDiary::class.java))
+            finish()
         }, 5000)
     }
+    fun getUserId(context: Context): String {
+        val prefs = context.getSharedPreferences("MyPrefs", Context.MODE_PRIVATE)
+        var userId = prefs.getString("userId", null)
+
+        if (userId == null) {
+            userId = UUID.randomUUID().toString()
+            prefs.edit().putString("userId", userId).apply()
+        }
+
+        return userId
+    }
+
 }
 
 

--- a/app/src/main/java/com/example/timecapsule/MainDiary.kt
+++ b/app/src/main/java/com/example/timecapsule/MainDiary.kt
@@ -1,0 +1,37 @@
+package com.example.timecapsule
+
+import android.os.Bundle
+import android.view.View
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+
+class MainDiary : AppCompatActivity() {
+
+    private lateinit var fabMenuLayout: LinearLayout
+    private lateinit var fabMain: TextView // 만약 TextView 기반 버튼일 경우
+    // private lateinit var fabMain: FloatingActionButton // 진짜 FAB일 경우 이걸로
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_maindiary)
+
+        fabMenuLayout = findViewById(R.id.fabMenuLayout)
+        fabMain = findViewById(R.id.fab_custom)
+
+        // FAB 클릭 → 메뉴 토글
+        fabMain.setOnClickListener {
+            if (fabMenuLayout.visibility == View.GONE) {
+                fabMenuLayout.visibility = View.VISIBLE
+            } else {
+                fabMenuLayout.visibility = View.GONE
+            }
+        }
+
+        // 메뉴 안 버튼들 기능 연결
+
+
+
+    }
+}

--- a/app/src/main/java/com/example/timecapsule/MainDiary.kt
+++ b/app/src/main/java/com/example/timecapsule/MainDiary.kt
@@ -1,11 +1,15 @@
 package com.example.timecapsule
 
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
 import android.widget.Button
+import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.StaggeredGridLayoutManager
 
 class MainDiary : AppCompatActivity() {
 
@@ -16,6 +20,31 @@ class MainDiary : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_maindiary)
+
+        val container = findViewById<FrameLayout>(R.id.containerView)
+
+// 먼저 기존 뷰 지우고
+        container.removeAllViews()
+
+// RecyclerView 레이아웃 inflate 해서 추가
+        val inflater = LayoutInflater.from(this)
+        val recyclerView = inflater.inflate(R.layout.recycler_polaroid, container, false) as RecyclerView
+
+// LayoutManager 설정 (크기 다양하게 할 거면 Staggered 추천)
+        recyclerView.layoutManager = StaggeredGridLayoutManager(3, StaggeredGridLayoutManager.VERTICAL)
+
+// 데이터 연결
+        val dummyList = listOf(
+            DiaryEntry("sample1.jpg", "😊", "기분 최고!", "2025-06-01", 0.0, 0.0),
+            DiaryEntry("sample2.jpg", "😌", "혼자 걷는 산책길", "2025-06-03", 0.0, 0.0)
+        )
+        val adapter = PolaroidAdapter(dummyList)
+        recyclerView.adapter = adapter
+
+// containerView 안에 RecyclerView 넣기
+        container.addView(recyclerView)
+
+
 
         fabMenuLayout = findViewById(R.id.fabMenuLayout)
         fabMain = findViewById(R.id.fab_custom)

--- a/app/src/main/java/com/example/timecapsule/MainDiary.kt
+++ b/app/src/main/java/com/example/timecapsule/MainDiary.kt
@@ -10,12 +10,15 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import java.util.Calendar
 
 class MainDiary : AppCompatActivity() {
 
     private lateinit var fabMenuLayout: LinearLayout
     private lateinit var fabMain: TextView // 만약 TextView 기반 버튼일 경우
     // private lateinit var fabMain: FloatingActionButton // 진짜 FAB일 경우 이걸로
+    private var isPolaroidMode = true
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -23,28 +26,7 @@ class MainDiary : AppCompatActivity() {
 
         val container = findViewById<FrameLayout>(R.id.containerView)
 
-// 먼저 기존 뷰 지우고
         container.removeAllViews()
-
-// RecyclerView 레이아웃 inflate 해서 추가
-        val inflater = LayoutInflater.from(this)
-        val recyclerView = inflater.inflate(R.layout.recycler_polaroid, container, false) as RecyclerView
-
-// LayoutManager 설정 (크기 다양하게 할 거면 Staggered 추천)
-        recyclerView.layoutManager = StaggeredGridLayoutManager(3, StaggeredGridLayoutManager.VERTICAL)
-
-// 데이터 연결
-        val dummyList = listOf(
-            DiaryEntry("sample1.jpg", "😊", "기분 최고!", "2025-06-01", 0.0, 0.0),
-            DiaryEntry("sample2.jpg", "😌", "혼자 걷는 산책길", "2025-06-03", 0.0, 0.0)
-        )
-        val adapter = PolaroidAdapter(dummyList)
-        recyclerView.adapter = adapter
-
-// containerView 안에 RecyclerView 넣기
-        container.addView(recyclerView)
-
-
 
         fabMenuLayout = findViewById(R.id.fabMenuLayout)
         fabMain = findViewById(R.id.fab_custom)
@@ -56,11 +38,34 @@ class MainDiary : AppCompatActivity() {
             } else {
                 fabMenuLayout.visibility = View.GONE
             }
+
+        }
+        // 테마 전환 버튼 클릭 이벤트
+        val btnChangeTheme = findViewById<Button>(R.id.btnChangeTheme)
+        btnChangeTheme.setOnClickListener {
+            switchThemeMode()
+            fabMenuLayout.visibility = View.GONE
         }
 
-        // 메뉴 안 버튼들 기능 연결
-
-
-
+        // 초기 화면 설정 (예: 폴라로이드 모드)
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.containerView, PolaroidFragment())
+            .commit()
     }
+
+
+
+
+    private fun switchThemeMode() {
+        val transaction = supportFragmentManager.beginTransaction()
+        val newFragment = if (isPolaroidMode) CustomCalendarFragment() else PolaroidFragment()
+        transaction.replace(R.id.containerView, newFragment)
+        transaction.commit()
+        isPolaroidMode = !isPolaroidMode
+    }
+
+
+
+
+
 }

--- a/app/src/main/java/com/example/timecapsule/PolaroidAdapter.kt
+++ b/app/src/main/java/com/example/timecapsule/PolaroidAdapter.kt
@@ -1,0 +1,55 @@
+package com.example.timecapsule
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.cardview.widget.CardView
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+
+class PolaroidAdapter(private val itemList: List<DiaryEntry>) :
+    RecyclerView.Adapter<PolaroidAdapter.PolaroidViewHolder>() {
+
+    inner class PolaroidViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        val imageView: ImageView = itemView.findViewById(R.id.imageView)
+        val emotionText: TextView = itemView.findViewById(R.id.emotionText)
+        val summaryText: TextView = itemView.findViewById(R.id.summaryText)
+        val cardView: CardView = itemView.findViewById(R.id.cardView)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PolaroidViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_polaroid, parent, false)
+        return PolaroidViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: PolaroidViewHolder, position: Int) {
+        val item = itemList[position]
+
+        // 1. 이미지 불러오기 (Glide 권장)
+        Glide.with(holder.itemView.context)
+            .load(item.imageUrl)
+            .placeholder(R.drawable.ic_launcher_background) // 대체 이미지
+            .into(holder.imageView)
+
+        // 2. 감정 이모지
+        holder.emotionText.text = item.emotion
+
+        // 3. 내용 요약 (한 줄만 표시되게 XML에서 처리함)
+        holder.summaryText.text = item.summary
+
+        // 4. 회전각 랜덤 (-8도 ~ +8도)
+        val rotation = (-5..5).random()
+        holder.cardView.rotation = rotation.toFloat()
+
+        // 5. 크기 랜덤 (너무 다르면 레이아웃 무너짐 → 살짝만 조절)
+        val layoutParams = holder.cardView.layoutParams
+        layoutParams.height = (400..440).random()
+        holder.cardView.layoutParams = layoutParams
+
+    }
+
+    override fun getItemCount(): Int = itemList.size
+}

--- a/app/src/main/java/com/example/timecapsule/PolaroidFragment.kt
+++ b/app/src/main/java/com/example/timecapsule/PolaroidFragment.kt
@@ -1,0 +1,38 @@
+package com.example.timecapsule
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.StaggeredGridLayoutManager
+
+class PolaroidFragment : Fragment() {
+
+    private lateinit var recyclerView: RecyclerView
+    private lateinit var adapter: PolaroidAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.recycler_polaroid, container, false) // 기존 레이아웃 재사용!
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        recyclerView = view.findViewById(R.id.polaroidRecyclerView) // recycler_polaroid.xml에 있는 RecyclerView ID
+        recyclerView.setHasFixedSize(true)
+
+        recyclerView.layoutManager = StaggeredGridLayoutManager(3, StaggeredGridLayoutManager.VERTICAL)
+
+        // ✅ 어댑터 연결
+        val dummyList = listOf(
+            DiaryEntry("sample1.jpg", "😊", "기분 최고!", "2025-06-01", 0.0, 0.0),
+            DiaryEntry("sample2.jpg", "😌", "혼자 걷는 산책길", "2025-06-03", 0.0, 0.0)
+        )
+        recyclerView.adapter = PolaroidAdapter(dummyList)
+    }
+}

--- a/app/src/main/res/drawable/calendar_day_background.xml
+++ b/app/src/main/res/drawable/calendar_day_background.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+   <shape xmlns:android="http://schemas.android.com/apk/res/android"
+        android:shape="rectangle">
+
+        <!-- 둥근 모서리 정도 설정 -->
+        <corners android:radius="12dp" />
+
+        <!-- 테두리 선 색 & 굵기 -->
+        <stroke
+            android:width="1dp"
+            android:color="#CCCCCC" />
+
+        <!-- 배경 색상 -->
+        <solid android:color="#FFFFFF" />
+    </shape>

--- a/app/src/main/res/drawable/fab_menu_24.xml
+++ b/app/src/main/res/drawable/fab_menu_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+
+    <path android:fillColor="#4A6658" android:pathData="M3,3h18v2h-18z"/>
+
+    <path android:fillColor="#4A6658" android:pathData="M3,19h18v2h-18z"/>
+
+    <path android:fillColor="#4A6658" android:pathData="M3,11h18v2h-18z"/>
+
+</vector>

--- a/app/src/main/res/drawable/rounded_btn_bg.xml
+++ b/app/src/main/res/drawable/rounded_btn_bg.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#ECE5DA" />
+    <corners android:radius="10dp"/>
+    <elevation android:state_enabled="true" />
+    <padding android:left="8dp" android:top="4dp" android:right="8dp" android:bottom="4dp"/>
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_maindiary.xml
+++ b/app/src/main/res/layout/activity_maindiary.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#ECE5DA"
+    tools:context=".MainDiary">
+
+    <!-- 제목 -->
+
+    <!-- 월 표시 -->
+
+    <TextView
+        android:id="@+id/titleText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="96dp"
+        android:text="my diary"
+        android:textColor="#4A6658"
+        android:textSize="35sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.498"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/dateText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="June"
+        android:textColor="#4A6658"
+        android:textSize="25sp"
+        android:layout_marginTop="12dp"
+        app:layout_constraintTop_toBottomOf="@id/titleText"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <!-- 이전 달 버튼 -->
+    <TextView
+        android:id="@+id/prevMonth"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="◀"
+        android:textSize="20sp"
+        android:textColor="#4A6658"
+        android:paddingEnd="16dp"
+        app:layout_constraintTop_toTopOf="@id/dateText"
+        app:layout_constraintBottom_toBottomOf="@id/dateText"
+        app:layout_constraintEnd_toStartOf="@id/dateText"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <!-- 다음 달 버튼 -->
+    <TextView
+        android:id="@+id/nextMonth"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="▶"
+        android:textSize="20sp"
+        android:textColor="#4A6658"
+        android:paddingStart="16dp"
+        app:layout_constraintTop_toTopOf="@id/dateText"
+        app:layout_constraintBottom_toBottomOf="@id/dateText"
+        app:layout_constraintStart_toEndOf="@id/dateText"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <!-- 동적으로 교체될 콘텐츠 영역 -->
+    <FrameLayout
+        android:id="@+id/containerView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="12dp"
+        app:layout_constraintTop_toBottomOf="@id/dateText"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <!-- 커스텀 FAB 버튼 -->
+
+    <!-- FAB 메뉴 포함 -->
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/fab_custom"
+        android:layout_width="60dp"
+        android:layout_height="60dp"
+        android:layout_marginTop="36dp"
+        android:layout_marginEnd="16dp"
+        android:backgroundTint="@android:color/transparent"
+        android:contentDescription="메뉴 열기 버튼"
+        android:gravity="center"
+        android:minWidth="0dp"
+        android:minHeight="0dp"
+        android:padding="0dp"
+        android:stateListAnimator="@null"
+        android:text="≡"
+        android:textColor="#4A6658"
+        android:textSize="40sp"
+        app:elevation="0dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <include
+        layout="@layout/fab_menu" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fab_menu.xml
+++ b/app/src/main/res/layout/fab_menu.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    >
+
+    <LinearLayout
+        android:id="@+id/fabMenuLayout"
+        android:orientation="vertical"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:layout_marginEnd="24dp"
+        android:layout_marginTop="88dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <Button
+            android:id="@+id/btnWriteToday"
+            android:layout_width="200dp"
+            android:layout_height="wrap_content"
+            android:text="오늘의 하루 쓰기"
+            android:textSize="14sp"
+            android:background="@drawable/rounded_btn_bg"
+            app:elevation="2dp"
+            android:gravity="center"/>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="#ECE5DA"
+            android:layout_marginVertical="2dp"/>
+
+        <Button
+            android:id="@+id/btnChangeTheme"
+            android:layout_width="200dp"
+            android:layout_height="wrap_content"
+            android:text="감정 통계 보기"
+            android:textSize="14sp"
+            android:background="@drawable/rounded_btn_bg"
+            app:elevation="2dp"
+            android:gravity="center"/>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="#ECE5DA"
+            android:layout_marginVertical="2dp"/>
+
+        <Button
+            android:id="@+id/btnLogout"
+            android:layout_width="200dp"
+            android:layout_height="wrap_content"
+            android:text="테마 변경"
+            android:textSize="14sp"
+            android:background="@drawable/rounded_btn_bg"
+            app:elevation="2dp"
+            android:gravity="center"/>
+    </LinearLayout>
+
+</merge>

--- a/app/src/main/res/layout/fab_menu.xml
+++ b/app/src/main/res/layout/fab_menu.xml
@@ -34,7 +34,7 @@
             android:layout_marginVertical="2dp"/>
 
         <Button
-            android:id="@+id/btnChangeTheme"
+            android:id="@+id/monthEmotion"
             android:layout_width="200dp"
             android:layout_height="wrap_content"
             android:text="감정 통계 보기"
@@ -50,7 +50,7 @@
             android:layout_marginVertical="2dp"/>
 
         <Button
-            android:id="@+id/btnLogout"
+            android:id="@+id/btnChangeTheme"
             android:layout_width="200dp"
             android:layout_height="wrap_content"
             android:text="테마 변경"

--- a/app/src/main/res/layout/fragment_custom_calendar.xml
+++ b/app/src/main/res/layout/fragment_custom_calendar.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/calendarRecyclerView"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="8dp"
+    android:clipToPadding="false"/>

--- a/app/src/main/res/layout/item_calendar_day.xml
+++ b/app/src/main/res/layout/item_calendar_day.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="100dp"
+    android:layout_margin="2dp"
+    android:gravity="top|start"
+    android:background="@drawable/calendar_day_background">
+
+    <TextView
+        android:id="@+id/dayNumber"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="start"
+        android:paddingStart="4dp"
+        android:paddingTop="4dp"
+        android:textColor="#000"
+        android:textSize="12sp"/>
+    <ImageView
+        android:id="@+id/dayImage"
+        android:layout_width="40dp"
+        android:layout_height="60dp"
+        android:scaleType="centerCrop"
+        android:visibility="gone"/>
+
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_polaroid.xml
+++ b/app/src/main/res/layout/item_polaroid.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/cardView"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    android:minHeight="280dp"
+    android:elevation="4dp"
+    android:foreground="?attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:background="@color/white">
+
+        <!-- 이미지 영역 -->
+        <ImageView
+            android:id="@+id/imageView"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="7"
+            android:scaleType="centerCrop"
+            android:adjustViewBounds="true" />
+
+        <!-- 감정 + 요약 텍스트 영역 -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="60dp"
+            android:orientation="vertical"
+            android:padding="8dp">
+
+            <TextView
+                android:id="@+id/emotionText"
+                android:layout_width="wrap_content"
+                android:layout_height="15dp"
+                android:layout_weight="5"
+                android:text="😊"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/summaryText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="기분 좋았던 하루"
+                android:textSize="14sp"
+                android:maxLines="1"
+                android:ellipsize="end"
+                android:textColor="@android:color/black" />
+        </LinearLayout>
+    </LinearLayout>
+
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/recycler_polaroid.xml
+++ b/app/src/main/res/layout/recycler_polaroid.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/polaroidRecyclerView"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:clipToPadding="false"
+    android:padding="12dp" />

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<!-- themes.xml -->
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.TimeCapsule" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="colorPrimary">#4A6658</item>
+        <item name="colorPrimaryVariant">#3B4F45</item>
+        <item name="colorSecondary">#D4B1B1</item>
+    </style>
 
-    <style name="Theme.TimeCapsule" parent="android:Theme.Material.Light.NoActionBar" />
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    id("com.google.gms.google-services") version "4.4.2" apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.10.1"
 composeBom = "2024.09.00"
+material = "1.12.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -24,6 +25,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.10.1"
 composeBom = "2024.09.00"
 material = "1.12.0"
+firebaseFirestoreKtx = "25.1.4"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -26,6 +27,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+firebase-firestore-ktx = { group = "com.google.firebase", name = "firebase-firestore-ktx", version.ref = "firebaseFirestoreKtx" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## PR 제목  
`feat: 폴라로이드 형식 다이어리 뷰 레이아웃 구현` -2025.06.16
`feat: 캘린더 뷰, FAB 전환 기능, Firestore 연동 구현` -2025.06.17

---

## 주요 작업 내용  
메인 다이어리 화면에서 한 달간의 다이어리 기록을 **폴라로이드 형식**으로 표시하는 UI를 구현했습니다.  
FAB 메뉴를 통해 선택된 보기 형식 중 하나로, 감성적인 카드 형태로 사진, 감정, 한 줄 요약을 보여줍니다.

+추가
메인 다이어리 화면에서 한 달간의 다이어리 기록을 **캘린더 형식**으로 표시하는 UI를 구현했습니다.  
FAB 메뉴를 통해 선택된 보기 형식 중 `테마 변경` 버튼 클릭 시 화면 간 전환이 가능하도록 했습니다.
Firebase에 연동했습니다.

---

## 구현 내용 요약  

## 2025.06.16
### `item_polaroid.xml`
- 카드뷰 기반 폴라로이드 카드 레이아웃 구현  
- 이미지 + 감정 이모지 + 요약 텍스트 영역 구성  
- `layout_weight` 기반 레이아웃 안정화

### `PolaroidAdapter.kt`
- 이미지 Glide 로딩  
- 카드 크기와 회전 랜덤 적용  
- RecyclerView의 각 항목에 데이터 바인딩 처리

### `MainDiary.kt`
- `containerView`에 RecyclerView를 동적으로 추가  
- `StaggeredGridLayoutManager` 사용하여 한 줄에 3개 카드 배치

## 2025.06.17
### `item_calendar_day.xml`
-  날짜 셀 레이아웃 구성 (모서리 둥근 박스)
-  날짜 숫자 `TextView`를 왼쪽 상단에 배치
-  이미지가 있는 날은 썸네일로 표시 가능
-  `FrameLayout`으로 이미지와 텍스트 겹치기 구조

### `CalendarFragment.kt`
-  커스텀 캘린더 UI 구현 (RecyclerView 기반)
-  날짜 리스트 동적 생성 → Adapter에 전달
-  추후 날짜 클릭 시 상세 뷰 전환 예정

### `CalendarAdapter.kt`
-  `onBindViewHolder` 내 날짜 및 이미지 바인딩 처리
-  Glide로 썸네일 로드 (없으면 `View.GONE`)
-  레이아웃 깨짐 없이 깔끔하게 처리

### `MainDiary.kt`
-  FAB 테마 전환 버튼 클릭 시
  - `PolaroidFragment` ↔ `CalendarFragment` **동적 전환** 처리
-  `supportFragmentManager.replace()` 사용
-  FAB 메뉴 버튼 클릭 시 메뉴 자동 닫힘 처리


---

## 관련 변경 사항
- 레이아웃 폴더에 `item_polaroid.xml` 추가 
- `item_polariod.xml`을 담을 `recycler_polaroid.xml` 추가 
- 폴라로이드 내 데이터를 담을 `DataEntry.kt` 데이터클래스 추가
- 새로운 어댑터 클래스 `PolaroidAdapter.kt` 추가  
- `MainDiary.kt`에서 RecyclerView 동적 inflate 로직 추가

---

## 현재 확인된 이슈 (related to #10 )

-  `com.google.android.gms` 관련 SecurityException 발생
-  그로 인해 `단말 고유 ID 생성 및 SharedPreferences 저장 + Firestore 문서 생성`이 실패 중
- `google-services.json`은 `app/` 폴더에 정상 위치
- `build.gradle.kts`에 `google.gms.google-services` 플러그인 설정 완료

---

## 이후 작업 예정

-  SHA-1 등록 및 `google-services.json` 교체 후 정상 연동 확인
-  위 문제 해결 후 ID 저장 로직 재확인 및 Firestore 문서 생성 확인
-  캘린더 내 `<`, `>` 버튼 클릭 시 월 단위 날짜 넘기기 기능 구현 예정

---

## 참고 사항
- 아직 DB 연동 전으로, 카드에 표시되는 사진, 감정, 내용은 **임의의 더미 데이터**를 사용하고 있음  
- 추후 Supabase 연동 시 `DiaryEntry` 리스트를 DB로부터 받아와 연결할 예정  
- 회전 및 크기 랜덤화는 감성 표현을 위해 간단히 적용했으며, 필요 시 사용자 설정으로 전환 가능

---

## 테스트 방법
1. 앱 실행 후 메인 다이어리 화면 진입 (메인화면이므로 실행 시 자동으로 진입 됨)
2. 한 줄에 3개 카드가 랜덤 회전/크기로 나타나는지 확인 (데이터베이스 연동 예정이라 더미 테이터 2개 뿐 -> 세개가 들어갈 자리인 지 확인)
3. 이미지, 감정 이모지, 한 줄 요약이 잘 보이는지 확인
4. Fab 버튼 내 `테마 변경` 버튼 클릭 시 테마 간 전환이 되는지 확인

Related to #9 
