### PR TITLE
날짜 변경 텍스트 버튼 구현

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-06-23T07:56:37.647417200Z">
+        <DropdownSelection timestamp="2025-06-23T08:48:25.608042800Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\B\.android\avd\test.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\B\.android\avd\Pixel_7.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     implementation("com.google.android.material:material:1.11.0")
     implementation("com.github.bumptech.glide:glide:4.16.0")
     implementation(libs.firebase.firestore.ktx)
+    implementation(libs.firebase.auth.ktx)
     kapt("com.github.bumptech.glide:compiler:4.16.0")
     implementation(platform("com.google.firebase:firebase-bom:32.7.3"))
     implementation("com.google.firebase:firebase-firestore-ktx:24.11.1")

--- a/app/src/main/java/com/example/timecapsule/PolaroidFragment.kt
+++ b/app/src/main/java/com/example/timecapsule/PolaroidFragment.kt
@@ -4,35 +4,81 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
+import java.time.LocalDate
 
 class PolaroidFragment : Fragment() {
 
     private lateinit var recyclerView: RecyclerView
     private lateinit var adapter: PolaroidAdapter
+    private lateinit var dateText: TextView
+
+    private var currentYear = LocalDate.now().year
+    private var currentMonth = LocalDate.now().monthValue
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.recycler_polaroid, container, false) // 기존 레이아웃 재사용!
+        return inflater.inflate(R.layout.recycler_polaroid, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        recyclerView = view.findViewById(R.id.polaroidRecyclerView) // recycler_polaroid.xml에 있는 RecyclerView ID
+        recyclerView = view.findViewById(R.id.polaroidRecyclerView)
         recyclerView.setHasFixedSize(true)
-
         recyclerView.layoutManager = StaggeredGridLayoutManager(3, StaggeredGridLayoutManager.VERTICAL)
 
-        // ✅ 어댑터 연결
-        val dummyList = listOf(
-            DiaryEntry("sample1.jpg", "😊", "기분 최고!", "2025-06-01", 0.0, 0.0),
-            DiaryEntry("sample2.jpg", "😌", "혼자 걷는 산책길", "2025-06-03", 0.0, 0.0)
-        )
-        recyclerView.adapter = PolaroidAdapter(dummyList)
+        dateText = view.findViewById(R.id.dateText)
+        val btnPrev = view.findViewById<TextView>(R.id.prevMonth)
+        val btnNext = view.findViewById<TextView>(R.id.nextMonth)
+
+        btnPrev.setOnClickListener {
+            if (currentMonth == 1) {
+                currentMonth = 12
+                currentYear -= 1
+            } else {
+                currentMonth -= 1
+            }
+            loadDummyData()
+        }
+
+        btnNext.setOnClickListener {
+            if (currentMonth == 12) {
+                currentMonth = 1
+                currentYear += 1
+            } else {
+                currentMonth += 1
+            }
+            loadDummyData()
+        }
+
+        loadDummyData()
+    }
+
+    private fun loadDummyData() {
+        dateText.text = "${currentYear}년 ${currentMonth}월"
+
+        // 👉 월에 따라 더미 리스트 다르게 만들기
+        val dummyList = when (currentMonth) {
+            6 -> listOf(
+                DiaryEntry("sample1.jpg", "😊", "기분 최고!", "2025-06-01", 0.0, 0.0),
+                DiaryEntry("sample2.jpg", "😌", "혼자 걷는 산책길", "2025-06-03", 0.0, 0.0)
+            )
+            5 -> listOf(
+                DiaryEntry("sample3.jpg", "🌸", "벚꽃구경", "2025-05-05", 0.0, 0.0),
+                DiaryEntry("sample4.jpg", "🎵", "음악회 다녀옴", "2025-05-21", 0.0, 0.0)
+            )
+            else -> listOf(
+                DiaryEntry("default.jpg", "📷", "아직 기록이 없어요!", "$currentYear-$currentMonth-01", 0.0, 0.0)
+            )
+        }
+
+        adapter = PolaroidAdapter(dummyList)
+        recyclerView.adapter = adapter
     }
 }

--- a/app/src/main/res/layout/activity_maindiary.xml
+++ b/app/src/main/res/layout/activity_maindiary.xml
@@ -25,45 +25,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
-        android:id="@+id/dateText"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="June"
-        android:textColor="#4A6658"
-        android:textSize="25sp"
-        android:layout_marginTop="12dp"
-        app:layout_constraintTop_toBottomOf="@id/titleText"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
-
-    <!-- 이전 달 버튼 -->
-    <TextView
-        android:id="@+id/prevMonth"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="◀"
-        android:textSize="20sp"
-        android:textColor="#4A6658"
-        android:paddingEnd="16dp"
-        app:layout_constraintTop_toTopOf="@id/dateText"
-        app:layout_constraintBottom_toBottomOf="@id/dateText"
-        app:layout_constraintEnd_toStartOf="@id/dateText"
-        app:layout_constraintStart_toStartOf="parent" />
-
-    <!-- 다음 달 버튼 -->
-    <TextView
-        android:id="@+id/nextMonth"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="▶"
-        android:textSize="20sp"
-        android:textColor="#4A6658"
-        android:paddingStart="16dp"
-        app:layout_constraintTop_toTopOf="@id/dateText"
-        app:layout_constraintBottom_toBottomOf="@id/dateText"
-        app:layout_constraintStart_toEndOf="@id/dateText"
-        app:layout_constraintEnd_toEndOf="parent" />
 
     <!-- 동적으로 교체될 콘텐츠 영역 -->
     <FrameLayout
@@ -71,7 +32,7 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginTop="12dp"
-        app:layout_constraintTop_toBottomOf="@id/dateText"
+        app:layout_constraintTop_toBottomOf="@id/titleText"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/recycler_polaroid.xml
+++ b/app/src/main/res/layout/recycler_polaroid.xml
@@ -1,7 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/polaroidRecyclerView"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:clipToPadding="false"
-    android:padding="12dp" />
+    android:orientation="vertical">
+
+    <!-- 🔹 월 이동 버튼 영역 -->
+    <LinearLayout
+        android:id="@+id/monthNavigation"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="horizontal"
+        android:padding="12dp">
+
+        <TextView
+            android:id="@+id/prevMonth"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="◀"
+            android:textSize="20sp"
+            android:textColor="#4A6658"
+            android:paddingEnd="16dp" />
+
+        <TextView
+            android:id="@+id/dateText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="2025년 6월"
+            android:textSize="18sp"
+            android:textColor="#4A6658" />
+
+        <TextView
+            android:id="@+id/nextMonth"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="▶"
+            android:textSize="20sp"
+            android:textColor="#4A6658"
+            android:paddingStart="16dp" />
+    </LinearLayout>
+
+    <!-- 🔸 폴라로이드 목록 RecyclerView -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/polaroidRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:clipToPadding="false"
+        android:padding="12dp" />
+</LinearLayout>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ activityCompose = "1.10.1"
 composeBom = "2024.09.00"
 material = "1.12.0"
 firebaseFirestoreKtx = "25.1.4"
+firebaseAuthKtx = "23.2.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -28,6 +29,7 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 firebase-firestore-ktx = { group = "com.google.firebase", name = "firebase-firestore-ktx", version.ref = "firebaseFirestoreKtx" }
+firebase-auth-ktx = { group = "com.google.firebase", name = "firebase-auth-ktx", version.ref = "firebaseAuthKtx" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Pull Request: 월 이동 기능 및 레이아웃 구조 개선

### PR 제목
`feat: 월 이동 버튼 구현 및 레이아웃 분리`

---

### 주요 작업 내용
- `PolaroidFragment.kt`에 ◀ / ▶ 버튼 클릭 시 월 변경 기능 추가
- `MainDiary.xml`에 있던 버튼(`prevMonth`, `nextMonth`, `dateText`)을 제거하고 `recycler_polaroid.xml`로 이동
- 현재 Firestore 연동 전이므로 월별 dummyList로 테스트 가능하도록 구성

---

### 구현 내용 요약
- `currentYear`, `currentMonth`를 기준으로 현재 날짜 관리
- `◀`, `▶` 버튼 클릭 시 월 변경 및 해당 월에 맞는 더미 다이어리 목록 표시
- 날짜는 상단 `TextView`에 `2025년 6월` 형식으로 출력
- 추후 Firestore 연동 시 `loadDummyData()`만 교체하면 바로 적용 가능

---

### 관련 변경 사항
#### PolaroidFragment.kt
- `onViewCreated()`에 버튼 클릭 리스너 추가
- `loadDummyData()` 함수로 더미 데이터 관리
- `RecyclerView`에 다이어리 카드 리스트 표시

#### recycler_polaroid.xml
- 기존 단독 `RecyclerView` → `LinearLayout`으로 전체 감싸기
- 상단에 월 변경 버튼(`prevMonth`, `nextMonth`)과 날짜 텍스트(`dateText`) 추가

#### mainDiary.xml
- 기존에 포함되어 있던 `prevMonth`, `nextMonth`, `dateText` 제거

---

### 현재 확인된 이슈
- Firestore에서 실제 다이어리 데이터를 불러오는 기능은 아직 미구현
- 현재는 `dummyList`로 테스트만 가능
- Firestore 연동 이후에는 `loadMonthDataFromFirestore()`로 교체 필요

---

### 시연 영상  
🎥 [시연영상 다운로드](https://raw.githubusercontent.com/wonna-0830/TimeCapsuleDiary-kotlinmain/images/monthchange.webm)

---

### 참고사항
- 월별 key는 `"yyyy-MM"` 포맷으로 변환할 예정 (`String.format("%04d-%02d", year, month)`)
- 이후 Firebase Storage에서 이미지도 불러와야 하며, 현재는 `sample1.jpg` 등 더미 경로 사용

---

### 테스트 방법
1. 앱 실행 후 폴라로이드 뷰 확인
2. 상단 `◀`, `▶` 버튼 클릭
3. 날짜 텍스트가 바뀌는지 확인 (`2025년 6월`, `2025년 5월` 등)
4. 화면에 표시되는 카드도 월에 맞게 변경되는지 확인
   - 6월 → sample1.jpg / sample2.jpg
   - 5월 → sample3.jpg / sample4.jpg
   - 기타 월 → "기록이 없어요!" 표시

close #6 
